### PR TITLE
Issue 8 & 10 - Add more milestones and several other changes

### DIFF
--- a/public/timeline.json
+++ b/public/timeline.json
@@ -6,7 +6,7 @@
       "credit": "Background: <a href='https://unsplash.com/photos/mk7D-4UCfmg'>https://unsplash.com/photos/mk7D-4UCfmg</a>"
     },
     "text": {
-      "headline": "The Story of WordPress<br/> 2001 - 2018",
+      "headline": "The Story of WordPress<br/> 2001 - 2019",
       "text": "<p>WordPress was born out of a desire for an elegant, well-architectured personal publishing system built on PHP and MySQL and licensed under the GPL. It is the official successor of b2/cafelog. WordPress is modern software, but its roots and development go back to 2001.</p>"
     }
   },
@@ -94,12 +94,23 @@
     },
     {
       "start_date": {
+        "day": "27",
+        "month": "05",
+        "year": "2003"
+      },
+      "text": {
+        "headline": "WordPress 0.7",
+        "text": "<p>As the first official public release of WordPress.</p>"
+      }
+    },
+    {
+      "start_date": {
         "day": "03",
         "month": "01",
         "year": "2004"
       },
       "text": {
-        "headline": "WordPress 1.0 (Code name: Davis) was released",
+        "headline": "WordPress 1.0 (Code name: Davis)",
         "text": "<p>Added search engine friendly permanent links, multiple categories, dead simple installation and upgrade, comment moderation, XFN support, Atom support.</p>"
       }
     },
@@ -115,7 +126,7 @@
         "year": "2004"
       },
       "text": {
-        "headline": "WordPress 1.2 (Code name: Mingus) launched",
+        "headline": "WordPress 1.2 (Code name: Mingus)",
         "text": "<p>Plugins were introduced, the first plugin is Hello Dolly.<br/>Internationalization was another major advancement.</p>"
       }
     },
@@ -130,63 +141,7 @@
         "year": "2005"
       },
       "text": {
-        "headline": "WordPress 1.5 (Code name: Strayhorn) launched",
-        "text": "<p>WordPress 1.5 got its theme system.</p>"
-      }
-    },
-    {
-      "media": {
-        "url": "/img/wordpress-2-0.png",
-        "caption": "WordPress 2.0 admin interface",
-        "credit": "<a href='http://www.wpbeginner.com/news/the-history-of-wordpress/'>http://www.wpbeginner.com/news/the-history-of-wordpress/</a>"
-      },
-      "start_date": {
-        "day": "31",
-        "month": "12",
-        "year": "2005"
-      },
-      "text": {
-        "headline": "WordPress 2.0 (Code name: Duke) was released",
-        "text": "<p>WordPress 2.0 was released with a new admin dashboard.</p>"
-      }
-    },
-    {
-      "start_date": {
-        "day": "27",
-        "month": "05",
-        "year": "2003"
-      },
-      "text": {
-        "headline": "WordPress 0.7 was released",
-        "text": "<p>As the first official public release of WordPress.</p>"
-      }
-    },
-    {
-      "media": {
-        "url": "/img/plugin-directory-2005.jpg",
-        "caption": "The first version of the WordPress Plugin Directory, in late 2005",
-        "credit": "<a href='https://github.com/WordPress/book/blob/master/Content/Part%202/11-birth-of-wp-hackers.md' target='_blank'>https://github.com/WordPress/book</a>"
-      },
-      "start_date": {
-        "day": "22",
-        "month": "05",
-        "year": "2004"
-      },
-      "text": {
-        "headline": "WordPress 1.2 launched",
-        "text": "<p>Plugins were introduced, the first plugin is Hello Dolly.<br/>Internationalization was another major advancement.</p>"
-      }
-    },
-    {
-      "media": {
-        "url": "/img/kubrick.jpg",
-        "caption": "The default theme of WordPress until 2010"
-      },
-      "start_date": {
-        "year": "2005"
-      },
-      "text": {
-        "headline": "WordPress 1.5 launched",
+        "headline": "WordPress 1.5 (Code name: Strayhorn)",
         "text": "<p>WordPress 1.5 got its theme system.</p>"
       }
     },
@@ -212,11 +167,12 @@
         "credit": "<a href='http://www.wpbeginner.com/news/the-history-of-wordpress/'>http://www.wpbeginner.com/news/the-history-of-wordpress/</a>"
       },
       "start_date": {
+        "day": "31",
         "month": "12",
         "year": "2005"
       },
       "text": {
-        "headline": "WordPress 2.0",
+        "headline": "WordPress 2.0 (Code name: Duke)",
         "text": "<p>WordPress 2.0 was released with a new admin dashboard.</p>"
       }
     },
@@ -240,7 +196,7 @@
         "year": "2007"
       },
       "text": {
-        "headline": "WordPress 2.1 (Code name: Ella) was released",
+        "headline": "WordPress 2.1 (Code name: Ella)",
         "text": "<p>Corrected security issues, redesigned interface, enhanced editing tools (including integrated spell check and auto save), and improved content management options.</p>"
       }
     },
@@ -251,7 +207,7 @@
         "year": "2007"
       },
       "text": {
-        "headline": "WordPress 2.2 (Code name: Getz) was released",
+        "headline": "WordPress 2.2 (Code name: Getz)",
         "text": "<p>Introduced the Widgets.</p>"
       }
     },
@@ -262,7 +218,7 @@
         "year": "2007"
       },
       "text": {
-        "headline": "WordPress 2.3 (Code name: Dexter) was released",
+        "headline": "WordPress 2.3 (Code name: Dexter)",
         "text": "<p>Added native tagging support, new taxonomy system for categories, and easy notification of updates, fully supports Atom 1.0, with the publishing protocol, and some much needed security fixes.</p>"
       }
     },
@@ -278,7 +234,7 @@
         "year": "2008"
       },
       "text": {
-        "headline": "WordPress 2.5 (Code name: Brecker) was released",
+        "headline": "WordPress 2.5 (Code name: Brecker)",
         "text": "<p>It was released with a new administration UI design by Happy Cog, and introduced the dashboard widget system and the shortcode API.</p>"
       }
     },
@@ -289,7 +245,7 @@
         "year": "2008"
       },
       "text": {
-        "headline": "WordPress 2.6 (Code name: Tyner) was released",
+        "headline": "WordPress 2.6 (Code name: Tyner)",
         "text": "<p>Added native tagging support, new taxonomy system for categories, and easy notification of updates, fully supports Atom 1.0, with the publishing protocol, and some much needed security fixes.</p>"
       }
     },
@@ -305,7 +261,7 @@
         "year": "2008"
       },
       "text": {
-        "headline": "WordPress 2.7 (Code name: Coltrane) was released",
+        "headline": "WordPress 2.7 (Code name: Coltrane)",
         "text": "<p>Redesigned the administration UI to improve usability and make the admin tool more customizable. Version 2.7 also introduced automatic upgrading, built-in plugin installation, sticky posts, comment threading/paging/replies and a new API, bulk management, and inline documentation.</p>"
       }
     },
@@ -316,7 +272,7 @@
         "year": "2009"
       },
       "text": {
-        "headline": "WordPress 2.8 (Code name: Dexter) was released",
+        "headline": "WordPress 2.8 (Code name: Dexter)",
         "text": "<p>Added improvements in speed, automatic installing of themes from within administration interface, introduces the CodePress editor for syntax highlighting and a redesigned widget interface.</p>"
       }
     },
@@ -327,7 +283,7 @@
         "year": "2009"
       },
       "text": {
-        "headline": "WordPress 2.9 (Code name: Carmen) was released",
+        "headline": "WordPress 2.9 (Code name: Carmen)",
         "text": "<p>Added global undo, built-in image editor, batch plugin updating, and many less visible tweaks.</p>"
       }
     },
@@ -343,7 +299,7 @@
         "year": "2010"
       },
       "text": {
-        "headline": "WordPress 3.0 (Code name: Thelonious) was released",
+        "headline": "WordPress 3.0 (Code name: Thelonious)",
         "text": "<p>It introduced custom post types, made custom taxonomies simpler, added custom menu management, added new API's for custom headers and custom backgrounds, introduced a new default theme called <strong>Twenty Ten</strong> (which started the tradition of a new default theme for each year) and allowed the management of multiple sites (called MultiSite).</p>"
       }
     },
@@ -354,7 +310,7 @@
         "year": "2011"
       },
       "text": {
-        "headline": "WordPress 3.1 (Code name: Reinhardt) was released",
+        "headline": "WordPress 3.1 (Code name: Reinhardt)",
         "text": "<p>Added the Admin Bar, which is displayed on all blog pages when an admin is logged in, and Post Format, best explained as a Tumblr like micro-blogging feature. It provides easy access to many critical functions, such as comments and updates. Includes internal linking abilities, a newly streamlined writing interface, and many other changes.</p>"
       }
     },
@@ -365,7 +321,7 @@
         "year": "2011"
       },
       "text": {
-        "headline": "WordPress 3.2 (Code name: Gershwin) was released",
+        "headline": "WordPress 3.2 (Code name: Gershwin)",
         "text": "<p>Focused on making WordPress faster and lighter. Released only four months after version 3.1, reflecting the growing speed of development in the WordPress community.</p>"
       }
     },
@@ -376,7 +332,7 @@
         "year": "2011"
       },
       "text": {
-        "headline": "WordPress 3.3 (Code name: Sonny) was released",
+        "headline": "WordPress 3.3 (Code name: Sonny)",
         "text": "<p>Focused on making WordPress friendlier for beginners and tablet computer users.</p>"
       }
     },
@@ -387,7 +343,7 @@
         "year": "2012"
       },
       "text": {
-        "headline": "WordPress 3.4 (Code name: Green) was released",
+        "headline": "WordPress 3.4 (Code name: Green)",
         "text": "<p>Focused on improvements to theme customization, Twitter integration and several minor changes.</p>"
       }
     },
@@ -403,7 +359,7 @@
         "year": "2012"
       },
       "text": {
-        "headline": "WordPress 3.5 (Code name: Elvin) was released",
+        "headline": "WordPress 3.5 (Code name: Elvin)",
         "text": "<p>Support for the Retina Display, color picker, new default theme <strong>Twenty Twelve</strong>, improved image workflow.</p>"
       }
     },
@@ -419,7 +375,7 @@
         "year": "2013"
       },
       "text": {
-        "headline": "WordPress 3.6 (Code name: Oscar) was released",
+        "headline": "WordPress 3.6 (Code name: Oscar)",
         "text": "<p>New default theme <strong>Twenty Thirteen</strong>, admin enhancements, post formats UI update, menus UI improvements, new revision system, auto save and post locking.</p>"
       }
     },
@@ -430,7 +386,7 @@
         "year": "2013"
       },
       "text": {
-        "headline": "WordPress 3.7 (Code name: Basie) was released",
+        "headline": "WordPress 3.7 (Code name: Basie)",
         "text": "<p>Automatically apply maintenance and security updates in the background, stronger password recommendations, support for automatically installing the right language files and keeping them up to date.</p>"
       }
     },
@@ -446,7 +402,7 @@
         "year": "2013"
       },
       "text": {
-        "headline": "WordPress 3.8 - Parker<br />Introduced a modern new design",
+        "headline": "WordPress 3.8 (Code name: Parker)<br />Introduced a modern new design",
         "text": "<p>WordPress has gotten a facelift. 3.8 brings a fresh new look to the entire admin dashboard. Gone are overbearing gradients and dozens of shades of grey — bring on a bigger, bolder, more colorful design!</p>"
       }
     },
@@ -473,7 +429,7 @@
         "year": "2014"
       },
       "text": {
-        "headline": "Version 4.0",
+        "headline": "WordPress 4.0",
         "text": "<ol><li>Media Library (Explore your uploads in a beautiful, endless grid)</li><li>Embeds improvements (embedding has become a visual experience.)</li><li>Improved Plugin Installation (new metrics, improved search, and a more visual browsing experience.)</ol>"
       }
     },
@@ -487,7 +443,7 @@
         "year": "2014"
       },
       "text": {
-        "headline": "Version 4.1",
+        "headline": "WordPress 4.1",
         "text": "<ol><li>Twenty Fifteen Theme released</li><li>Distraction-free writing</li><li>Choose a language (You can switch to any translation on the General Settings screen.)</li><li>Log out everywhere</li><li>Vine embeds (Embedding videos from Vine)</li><li>Plugin recommendations (The plugin installer suggests plugins for you to try)</li></ol>"
       }
     },
@@ -501,7 +457,7 @@
         "year": "2015"
       },
       "text": {
-        "headline": "Version 4.2",
+        "headline": "WordPress 4.2",
         "text": "<ol><li>share content easier (Improved Press This plugin)</li><li>Extended character support (Including native Chinese, Japanese, and Korean characters, musical and mathematical symbols, hieroglyphs and emoji support.</li><li>Streamlined plugin updates</li></ol>"
       }
     },
@@ -515,7 +471,7 @@
         "year": "2015"
       },
       "text": {
-        "headline": "Version 4.3",
+        "headline": "WordPress 4.3",
         "text": "<ol><li>Menus in the Customizer</li><li>Formatting Shortcuts</li><li>Site Icons</li><li>Better Passwords</li></ol>"
       }
     },
@@ -529,7 +485,7 @@
         "year": "2015"
       },
       "text": {
-        "headline": "Version 4.4",
+        "headline": "WordPress 4.4",
         "text": "<ol><li>Twenty Sixteen Theme released</li><li>Responsive Images (WordPress now takes a smarter approach to displaying appropriate image sizes on any device)</li><li>Embeds Feature (Now you can embed your posts on other WordPress sites)</li><li>REST API infrastructure</li></ol>"
       }
     },
@@ -543,7 +499,7 @@
         "year": "2016"
       },
       "text": {
-        "headline": "Version 4.5",
+        "headline": "WordPress 4.5",
         "text": "<ol><li>Editor Improvements</li><li>Live Responsive Previews(View mobile, tablet, and desktop previews in customizer)</li><li>Custom Logos(Themes can now support logos for your business or brand)</li></ol>"
       }
     },
@@ -557,7 +513,7 @@
         "year": "2016"
       },
       "text": {
-        "headline": "Version 4.6",
+        "headline": "WordPress 4.6",
         "text": "<ol><li>Streamlined Updates</li><li>Native Fonts</li><li>Editor Improvements</li></ol>"
       }
     },
@@ -571,7 +527,7 @@
         "year": "2016"
       },
       "text": {
-        "headline": "Version 4.7",
+        "headline": "WordPress 4.7",
         "text": "<ol><li>REST API</li><li>Post Type Templates</li><li>Customizer Improvements</li></ol>"
       }
     },
@@ -584,7 +540,7 @@
         "year": "2017"
       },
       "text": {
-        "headline": "58.7%",
+        "headline": "Stats: 58.7%",
         "text": "<p>58.7% of all the websites whose content management systems are known run WordPress</p><p>This is over 27% of the top 10 million websites.</p><p>Source: https://w3techs.com/technologies/overview/content_management/all/</p>"
       }
     },
@@ -598,7 +554,7 @@
         "year": "2017"
       },
       "text": {
-        "headline": "Version 4.8",
+        "headline": "WordPress 4.8",
         "text": "<ol><li>Dream widgets have been added: Image, video, audio, rich text.</li><li>Nearby WordPress Events</li></ol>"
       }
     },
@@ -612,7 +568,7 @@
         "year": "2017"
       },
       "text": {
-        "headline": "Version 4.9",
+        "headline": "WordPress 4.9",
         "text": "<ol><li>Draft and Schedule Site Design Customizations</li><li>The New Gallery Widget</li></ol>"
       }
     },
@@ -623,36 +579,28 @@
         "credit": "<a href='https://make.wordpress.org/core/5-0/' target='_blank'>https://make.wordpress.org/core/5-0/</a>"
       },
       "start_date": {
-        "day": "19",
-        "month": "11",
+        "day": "6",
+        "month": "12",
         "year": "2018"
       },
       "text": {
-        "headline": "Version 5.0",
-        "text": "<p>As per <a href='https://make.wordpress.org/core/5-0/' target='_blank'>WordPress 5.0 Development Cycle</a> page, WordPress 5.0 is schedule to be released on November 19, 2018. It will be the major release of 2018, including the new block editor, and the Twenty Nineteen theme.</p><ol><li>Gutenberg - new block editor</li><li>Twenty Nineteen theme</li></ol>"
+        "headline": "WordPress 5.0 (Code name: Bebo)",
+        "text": "<p>It is a major release of 2018, including the new block editor, and the Twenty Nineteen theme.</p><ol><li>Gutenberg - new block editor</li><li>Twenty Nineteen theme</li></ol>"
       }
     },
     {
       "media": {
-        "url": "./img/wpholiday-wordpress-desktop-2880x1800.jpg"
+        "url": "https://kinsta.com/wp-content/uploads/2019/03/wordpress-5-1-update-new-1.png",
+        "caption": "WordPress 5.1 - Moving PHP Forward",
+        "credit": "<a href='https://kinsta.com/blog/wordpress-5-1/' target='_blank'>https://kinsta.com/blog/wordpress-5-1/</a>"
       },
-      "start_date": {
-        "month": "01",
-        "year": "2019"
-      },
-      "text": {
-        "headline": "Summary",
-        "text": "<ol><li>Start with passion.</li><li>Responsibility and vision: GPL and Automattic</li><li>Focus on simplicity for users who do not know much about technology.</li><li>Developed regularly and actively.</li></ol>"
-      }
-    },
-    {
       "start_date": {
         "day": "21",
         "month": "02",
         "year": "2019"
       },
       "text": {
-        "headline": "WordPress 5.1 (Code name: Betty) was released",
+        "headline": "WordPress 5.1 (Code name: Betty)",
         "text": "<p>It focuses on polish, in particular by improving the overall performance of the editor. In addition, this release paves the way for a better, faster, and more secure WordPress with some essential tools for site administrators and developers.</p><ol><li>PHP version upgrade notices.</li><li>Improvements in the block editor.</li></ol>"
       }
     },
@@ -668,8 +616,37 @@
         "year": "2019"
       },
       "text": {
-        "headline": "WordPress 5.2 (Code name: Jaco) was released",
+        "headline": "WordPress 5.2 (Code name: Jaco)",
         "text": "<p>New features in this update make it easier than ever to fix your site if something goes wrong. There are even more robust tools for identifying and fixing configuration issues and fatal errors. Whether you are a developer helping clients or you manage your site solo, these tools can help get you the right information when you need it.</p><ol><li>Include site health check.</li><li>PHP error protection.</li><li>Accessibility updates.</li><li>New dashboard icons.</li><li>Plugin compatibility checks.</li></ol>"
+      }
+    },
+    {
+      "media": {
+        "url": "https://cdn3.wpbeginner.com/wp-content/uploads/2019/09/whatscominginwp53.png",
+        "caption": "WordPress 5.3 - New Blocks, New APIs, Improved Admin UI",
+        "credit": "<a href='https://www.wpbeginner.com/news/whats-coming-in-wordpress-5-3-features-and-screenshots/' target='_blank'>https://www.wpbeginner.com/news/whats-coming-in-wordpress-5-3-features-and-screenshots/</a>"
+      },
+      "start_date": {
+        "day": "12",
+        "month": "11",
+        "year": "2019"
+      },
+      "text": {
+        "headline": "WordPress 5.3",
+        "text": "<p>As per <a href='https://make.wordpress.org/core/5-3/' target='_blank'>WordPress 5.3 Development Cycle</a> page, WordPress 5.3 will be the final major release of 2019 and aims to polish current interactions and make the UIs more user friendly.</p><ol><li>Design and User Interface updates</li><li>New and improved blocks</li><li>Improved image uploads</li><li>Twenty Twenty theme</li></ol>"
+      }
+    },
+    {
+      "media": {
+        "url": "./img/wpholiday-wordpress-desktop-2880x1800.jpg"
+      },
+      "start_date": {
+        "month": "01",
+        "year": "2020"
+      },
+      "text": {
+        "headline": "Summary",
+        "text": "<ol><li>Start with passion.</li><li>Responsibility and vision: GPL and Automattic</li><li>Focus on simplicity for users who do not know much about technology.</li><li>Developed regularly and actively.</li></ol>"
       }
     }
   ]


### PR DESCRIPTION
In respect to Issue #8, following change was made: 

- [x] Add a new entry for **WordPress 5.3**

In respect to Issue #10, following changes were made:

- [x] Change the slideshow title - **The Story of WordPress 2001 - 2018** to **The Story of WordPress 2001 - 2019**
- [x] Sort the timeline events as per year on code level
- [x] Remove duplicate entries for **WordPress 1.2**, **1.5** and **2.0**
- [x] Change headlines for several entries to make them consistent
- [x] Add media URL where missing
- [x] Move **Summary** slide to the end of the slideshow
